### PR TITLE
Recurring tasks issue

### DIFF
--- a/5-Templates/Daily-Notes.md
+++ b/5-Templates/Daily-Notes.md
@@ -44,7 +44,7 @@ tR += rightAngle;
 > not done
 > (happens on or before <% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>) OR (status.type is IN_PROGRESS)
 > (heading does not include Focus) AND (heading does not include Goals)
-> group by function (task.description.includes("[[")) ? '%%1%% Projects' : result = !task.isRecurring ? '%%2%% Tasks' : '%%3%% Recurring Tasks'
+> group by function (task.isRecurring) ? '%%3%% Recurring Tasks' : result = task.description.includes("[[") ? '%%1%% Projects' : '%%2%% Tasks'
 > ```
 
 > [!IMPORTANT]+ Short Next Actions 🏃

--- a/5-Templates/Daily-Notes.md
+++ b/5-Templates/Daily-Notes.md
@@ -2,10 +2,10 @@
 title: <% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>
 date: <% moment(tp.file.creation_date()).format("YYYY-MM-DD HH:mm:ss") %>
 lastmod: <% moment(tp.file.creation_date()).format("YYYY-MM-DD HH:mm:ss") %>
-categories: 
+categories:
 tags: daily-notes
-aliases: 
-share: false 
+aliases:
+share: false
 ---
 
 # <% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>
@@ -51,10 +51,11 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #next
-> short mode
 > group by function task.tags.filter( (tag) => tag.includes("#next") )
+> short mode
 > ```
 
 ## Notes 📝
@@ -114,6 +115,7 @@ filter: "#Inbox"
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #next
 > group by function task.tags.filter( (tag) => ! tag.includes("#next") )
@@ -123,6 +125,7 @@ filter: "#Inbox"
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -135,6 +138,7 @@ filter: "#Inbox"
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #waiting
 > group by filename
@@ -144,6 +148,7 @@ filter: "#Inbox"
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #delegated
 > group by filename
@@ -153,6 +158,7 @@ filter: "#Inbox"
 >
 > ```tasks
 > not done
+> is not recurring
 > (path includes -Daily-Notes) OR (path includes -Periodic-Notes)
 > (heading includes Focus) AND (heading includes Goals)
 > group by function '%%' + (task.heading.includes("Yearly Focus 🔥 & Goals 🎯") ? "1" : task.heading.includes("Quarterly Focus 🔥 & Goals 🎯") ? "2" : task.heading.includes("Monthly Focus 🔥 & Goals 🎯") ? "3" : task.heading.includes("Weekly Focus 🔥 & Goals 🎯") ? "4" : task.heading.includes("Daily Focus 🔥 & Goals 🎯") ? "5" : "6") + '%%' + task.heading + " > " + task.file.filenameWithoutExtension + " > " + task.tags
@@ -164,6 +170,7 @@ filter: "#Inbox"
 >
 > ```tasks
 > not done
+> is not recurring
 > filename includes Passions Backlog 🎮
 > heading includes Doing
 > group by heading
@@ -175,7 +182,6 @@ filter: "#Inbox"
 >
 > ```tasks
 > not done
-> is not recurring
 > description includes ]]
 > created on <% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>
 > group by filename
@@ -185,7 +191,6 @@ filter: "#Inbox"
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > created on <% moment(tp.file.title, "YYYY-MM-DD").format("YYYY-MM-DD") %>
 > group by filename

--- a/5-Templates/Monthly-Notes.md
+++ b/5-Templates/Monthly-Notes.md
@@ -87,6 +87,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #next
 > group by function task.tags.filter( (tag) => ! tag.includes("#next") )
@@ -96,6 +97,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -108,6 +110,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #waiting
 > group by filename
@@ -117,6 +120,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #delegated
 > group by filename
@@ -126,6 +130,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > (path includes -Daily-Notes) OR (path includes -Periodic-Notes)
 > (heading includes Focus) AND (heading includes Goals)
 > group by function '%%' + (task.heading.includes("Yearly Focus 🔥 & Goals 🎯") ? "1" : task.heading.includes("Quarterly Focus 🔥 & Goals 🎯") ? "2" : task.heading.includes("Monthly Focus 🔥 & Goals 🎯") ? "3" : task.heading.includes("Weekly Focus 🔥 & Goals 🎯") ? "4" : task.heading.includes("Daily Focus 🔥 & Goals 🎯") ? "5" : "6") + '%%' + task.heading + " > " + task.file.filenameWithoutExtension + " > " + task.tags
@@ -137,6 +142,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -147,6 +153,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -156,16 +163,16 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 > [!INFO]+ Projects On Hold 🎯
 >
 > ```tasks
-> description includes ]]
 > status.type is NON_TASK
+> description includes ]]
 > group by filename
 > ```
 
 > [!INFO]+ Tasks On Hold ✅
 >
 > ```tasks
-> description does not include ]]
 > status.type is NON_TASK
+> description does not include ]]
 > group by filename
 > ```
 
@@ -185,7 +192,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > path includes -Daily-Notes
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -198,7 +204,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > (path does not include -Daily-Notes) AND (path does not include -Periodic-Notes)
 > filename does not include Passions Backlog 🎮
@@ -213,7 +218,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
-> is not recurring
 > description includes ]]
 > created on <% moment(tp.file.title, "YYYY-MM").format("YYYY-MM") %>
 > group by created
@@ -223,7 +227,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > created on <% moment(tp.file.title, "YYYY-MM").format("YYYY-MM") %>
 > group by created
@@ -233,7 +236,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > description includes ]]
-> is not recurring
 > done in <% moment(tp.file.title, "YYYY-MM").format("YYYY-MM") %>
 > group by done
 > ```
@@ -242,7 +244,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > description does not include ]]
-> is not recurring
 > done in <% moment(tp.file.title, "YYYY-MM").format("YYYY-MM") %>
 > group by done
 > ```

--- a/5-Templates/Quarterly-Notes.md
+++ b/5-Templates/Quarterly-Notes.md
@@ -79,6 +79,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #next
 > group by function task.tags.filter( (tag) => ! tag.includes("#next") )
@@ -88,6 +89,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -100,6 +102,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #waiting
 > group by filename
@@ -109,6 +112,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #delegated
 > group by filename
@@ -118,6 +122,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > (path includes -Daily-Notes) OR (path includes -Periodic-Notes)
 > (heading includes Focus) AND (heading includes Goals)
 > group by function '%%' + (task.heading.includes("Yearly Focus 🔥 & Goals 🎯") ? "1" : task.heading.includes("Quarterly Focus 🔥 & Goals 🎯") ? "2" : task.heading.includes("Monthly Focus 🔥 & Goals 🎯") ? "3" : task.heading.includes("Weekly Focus 🔥 & Goals 🎯") ? "4" : task.heading.includes("Daily Focus 🔥 & Goals 🎯") ? "5" : "6") + '%%' + task.heading + " > " + task.file.filenameWithoutExtension + " > " + task.tags
@@ -129,6 +134,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -139,6 +145,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -148,16 +155,16 @@ tR += rightAngle;
 > [!INFO]+ Projects On Hold 🎯
 >
 > ```tasks
-> description includes ]]
 > status.type is NON_TASK
+> description includes ]]
 > group by filename
 > ```
 
 > [!INFO]+ Tasks On Hold ✅
 >
 > ```tasks
-> description does not include ]]
 > status.type is NON_TASK
+> description does not include ]]
 > group by filename
 > ```
 
@@ -177,7 +184,6 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > path includes -Daily-Notes
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -190,7 +196,6 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > (path does not include -Daily-Notes) AND (path does not include -Periodic-Notes)
 > filename does not include Passions Backlog 🎮
@@ -205,7 +210,6 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
-> is not recurring
 > description includes ]]
 > created on <% moment(tp.file.title, "YYYY-[Q]Q").format("YYYY-[Q]Q") %>
 > group by created
@@ -215,7 +219,6 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > created on <% moment(tp.file.title, "YYYY-[Q]Q").format("YYYY-[Q]Q") %>
 > group by created
@@ -225,7 +228,6 @@ tR += rightAngle;
 >
 > ```tasks
 > description includes ]]
-> is not recurring
 > done in <% moment(tp.file.title, "YYYY-[Q]Q").format("YYYY-[Q]Q") %>
 > group by done
 > ```
@@ -234,7 +236,6 @@ tR += rightAngle;
 >
 > ```tasks
 > description does not include ]]
-> is not recurring
 > done in <% moment(tp.file.title, "YYYY-[Q]Q").format("YYYY-[Q]Q") %>
 > group by done
 > ```

--- a/5-Templates/Weekly-Notes.md
+++ b/5-Templates/Weekly-Notes.md
@@ -92,6 +92,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #next
 > group by function task.tags.filter( (tag) => ! tag.includes("#next") )
@@ -101,6 +102,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -113,6 +115,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #waiting
 > group by filename
@@ -122,6 +125,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #delegated
 > group by filename
@@ -131,6 +135,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > (path includes -Daily-Notes) OR (path includes -Periodic-Notes)
 > (heading includes Focus) AND (heading includes Goals)
 > group by function '%%' + (task.heading.includes("Yearly Focus 🔥 & Goals 🎯") ? "1" : task.heading.includes("Quarterly Focus 🔥 & Goals 🎯") ? "2" : task.heading.includes("Monthly Focus 🔥 & Goals 🎯") ? "3" : task.heading.includes("Weekly Focus 🔥 & Goals 🎯") ? "4" : task.heading.includes("Daily Focus 🔥 & Goals 🎯") ? "5" : "6") + '%%' + task.heading + " > " + task.file.filenameWithoutExtension + " > " + task.tags
@@ -142,6 +147,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -152,6 +158,7 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -161,16 +168,16 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 > [!INFO]+ Projects On Hold 🎯
 >
 > ```tasks
-> description includes ]]
 > status.type is NON_TASK
+> description includes ]]
 > group by filename
 > ```
 
 > [!INFO]+ Tasks On Hold ✅
 >
 > ```tasks
-> description does not include ]]
 > status.type is NON_TASK
+> description does not include ]]
 > group by filename
 > ```
 
@@ -190,7 +197,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > path includes -Daily-Notes
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -203,7 +209,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > (path does not include -Daily-Notes) AND (path does not include -Periodic-Notes)
 > filename does not include Passions Backlog 🎮
@@ -218,7 +223,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
-> is not recurring
 > description includes ]]
 > created on <% moment(tp.file.title, "GGGG-[W]WW").format("GGGG-[W]WW") %>
 > group by created
@@ -228,7 +232,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > created on <% moment(tp.file.title, "GGGG-[W]WW").format("GGGG-[W]WW") %>
 > group by created
@@ -238,7 +241,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > description includes ]]
-> is not recurring
 > done in <% moment(tp.file.title, "GGGG-[W]WW").format("GGGG-[W]WW") %>
 > group by done
 > ```
@@ -247,7 +249,6 @@ await dv.view("_Scripts", {pages: "dv.pages().file.where(f => f.folder != '_Sour
 >
 > ```tasks
 > description does not include ]]
-> is not recurring
 > done in <% moment(tp.file.title, "GGGG-[W]WW").format("GGGG-[W]WW") %>
 > group by done
 > ```

--- a/5-Templates/Yearly-Notes.md
+++ b/5-Templates/Yearly-Notes.md
@@ -80,6 +80,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #next
 > group by function task.tags.filter( (tag) => ! tag.includes("#next") )
@@ -89,6 +90,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -101,6 +103,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #waiting
 > group by filename
@@ -110,6 +113,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description does not include ]]
 > tags include #delegated
 > group by filename
@@ -119,6 +123,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > (path includes -Daily-Notes) OR (path includes -Periodic-Notes)
 > (heading includes Focus) AND (heading includes Goals)
 > group by function '%%' + (task.heading.includes("Yearly Focus 🔥 & Goals 🎯") ? "1" : task.heading.includes("Quarterly Focus 🔥 & Goals 🎯") ? "2" : task.heading.includes("Monthly Focus 🔥 & Goals 🎯") ? "3" : task.heading.includes("Weekly Focus 🔥 & Goals 🎯") ? "4" : task.heading.includes("Daily Focus 🔥 & Goals 🎯") ? "5" : "6") + '%%' + task.heading + " > " + task.file.filenameWithoutExtension + " > " + task.tags
@@ -130,6 +135,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -140,6 +146,7 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
+> is not recurring
 > description includes ]]
 > filename does not include Passions Backlog 🎮
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -149,16 +156,16 @@ tR += rightAngle;
 > [!INFO]+ Projects On Hold 🎯
 >
 > ```tasks
-> description includes ]]
 > status.type is NON_TASK
+> description includes ]]
 > group by filename
 > ```
 
 > [!INFO]+ Tasks On Hold ✅
 >
 > ```tasks
-> description does not include ]]
 > status.type is NON_TASK
+> description does not include ]]
 > group by filename
 > ```
 
@@ -178,7 +185,6 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > path includes -Daily-Notes
 > (heading does not include Focus) AND (heading does not include Goals)
@@ -191,7 +197,6 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > (path does not include -Daily-Notes) AND (path does not include -Periodic-Notes)
 > filename does not include Passions Backlog 🎮
@@ -206,7 +211,6 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
-> is not recurring
 > description includes ]]
 > created on <% moment(tp.file.title, "YYYY").format("YYYY") %>
 > group by created
@@ -216,7 +220,6 @@ tR += rightAngle;
 >
 > ```tasks
 > not done
-> is not recurring
 > description does not include ]]
 > created on <% moment(tp.file.title, "YYYY").format("YYYY") %>
 > group by created
@@ -226,7 +229,6 @@ tR += rightAngle;
 >
 > ```tasks
 > description includes ]]
-> is not recurring
 > done in <% moment(tp.file.title, "YYYY").format("YYYY") %>
 > group by done
 > ```
@@ -235,7 +237,6 @@ tR += rightAngle;
 >
 > ```tasks
 > description does not include ]]
-> is not recurring
 > done in <% moment(tp.file.title, "YYYY").format("YYYY") %>
 > group by done
 > ```


### PR DESCRIPTION
I recently came across an issue with recurring tasks query that was considered as a project because it needed some notes.

But according to my view of the GTD workflow, a project can't be recurring, only a task can.

So I decided to :
- Change the today query order so that recurring tasks are sorted out at first, before choosing between project and task
- Add some recurring task prevention to queries
- Remove unwanted recurring filters in `unplanned` queries and `log` queries